### PR TITLE
Add Elasticsearch integration documentation and update index.rst

### DIFF
--- a/.github/agents/docs-editor.agent.md
+++ b/.github/agents/docs-editor.agent.md
@@ -1,0 +1,37 @@
+---
+description: "Use when editing or reviewing G3W-SUITE end-user documentation sources. Trigger phrases: edit docs, update documentation, fix typo, rewrite section, add screenshot, check rst, check markdown, cross-reference, toctree, build Sphinx, make html."
+name: "G3W Docs Editor"
+tools: [read, edit, search, execute, todo]
+user-invocable: true
+---
+You are a documentation specialist for the **G3W-SUITE** end-user docs — a Sphinx project published on Read the Docs that mixes Markdown (`recommonmark`) and reStructuredText, with `sphinx_rtd_theme` and `sphinx_markdown_tables`. Sources live at the repo root.
+
+Write new content in **English first**; Italian translations are handled separately via the gettext workflow and are **out of scope** for this agent.
+
+## Scope
+
+- Edit `.md` and `.rst` files at the repo root (e.g. [g3wsuite_client.md](g3wsuite_client.md), [settings.rst](settings.rst), [index.rst](index.rst)).
+- Manage screenshots under [images/](images/) (`manual/{en,it}/`, `install/{en,it}/`, `config/`, `twofa/`). Place new English screenshots in the `en/` subfolders.
+- Keep the `toctree` in [index.rst](index.rst) consistent when adding or removing pages.
+- Run local Sphinx builds (`make html`) to validate changes.
+
+## Constraints
+
+- DO NOT edit `.po` or `.pot` files, or anything under [locales/](locales/) or `_build/locale/` — translation work belongs to a separate workflow.
+- DO NOT edit generated output under `_build/html/` or `_build/doctrees/` — these are build artifacts.
+- DO NOT mix Markdown syntax inside `.rst` files or vice versa.
+- DO NOT change `conf.py` settings, the Sphinx theme, or extensions without being asked.
+- DO NOT touch unrelated branches; assume the currently checked-out branch is the intended target.
+- Preserve existing image paths and relative links — verify with [search](#tool:search) before renaming.
+
+## Approach
+
+1. Identify whether the target file is Markdown or reStructuredText and match the existing heading style, indentation, and link/image syntax used in nearby files.
+2. For new pages, add the file to the appropriate `toctree` directive in [index.rst](index.rst).
+3. For screenshots, save under `images/manual/en/` (or `images/install/en/`) and reference them with the path style the existing pages use.
+4. When changes touch structure, links, or images, run `make html` and surface any Sphinx warnings about broken references, missing toctree entries, or duplicate labels.
+
+## Output Format
+
+- Apply edits directly with the [edit](#tool:edit) tool.
+- End with a one- or two-sentence summary listing the files changed and any follow-up the user should consider (e.g. "Italian translation needed", "rebuild HTML", "add screenshot").

--- a/elasticsearch.md
+++ b/elasticsearch.md
@@ -1,0 +1,183 @@
+# Elasticsearch integration (QES module)
+
+Starting from version 3.10, G3W-SUITE ships with the **`qes`** module (QGIS Elasticsearch), an optional component that indexes QGIS layer features into [Elasticsearch](https://www.elastic.co/elasticsearch) to provide fast, full-text search across the published WebGIS projects.
+
+The module is part of the [g3w-admin](https://github.com/g3w-suite/g3w-admin) codebase (`g3w-admin/qes/`) and is activated by adding `qes` to the `G3WADMIN_LOCAL_MORE_APPS` list in `local_settings.py`.
+
+## Overview
+
+When the module is enabled, G3W-SUITE will:
+
+- create one Elasticsearch index per user (`qgis_features_<user_pk>`, or `qgis_features_anonymous` for unauthenticated access) containing the features the user is authorized to see;
+- index attribute values and a derived `text_content` field used for full-text search;
+- keep the indexes synchronized with editing operations through Django signals (create / update / delete on vector layers managed by the `editing` module);
+- expose a REST endpoint that returns search hits for a given query within a project.
+
+Per-user indexes are used to respect G3W-SUITE permissions: each user only searches the subset of features they have access to.
+
+## Requirements
+
+- An Elasticsearch server reachable from G3W-ADMIN. The reference version used by the official Docker images is **Elasticsearch 8.18.x**.
+- The following Python packages (already declared in the g3w-admin `requirements.txt`):
+    - `django-elasticsearch-dsl==8.0`
+    - `elasticsearch` (installed as a transitive dependency)
+
+When `qes` is listed in `G3WADMIN_LOCAL_MORE_APPS`, G3W-SUITE automatically adds `django_elasticsearch_dsl` to `INSTALLED_APPS`.
+
+## Deploy with Docker
+
+The official `docker-compose.ltr.yml` / `docker-compose.latest.yml` files in [g3w-suite-docker](https://github.com/g3w-suite/g3w-suite-docker) include an `elasticsearch` service ready to use:
+
+```yaml
+elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.18.1
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+      - ES_JAVA_OPTS=-Xms512m -Xmx512m
+    volumes:
+      - esdata:/usr/share/elasticsearch/data
+    ports:
+      - "9200:9200"
+```
+
+The G3W-SUITE container reaches it through the internal Docker network at `http://elasticsearch:9200`.
+
+## Manual installation
+
+If you are not using the provided Docker compose stack, install and start an Elasticsearch 8.x instance on a host reachable by G3W-ADMIN, then configure the connection as described below.
+
+For installation instructions refer to the official documentation: <https://www.elastic.co/guide/en/elasticsearch/reference/current/install-elasticsearch.html>.
+
+## Configuration
+
+Add `qes` to the local apps and configure the Elasticsearch connection in `local_settings.py`:
+
+```python
+G3WADMIN_LOCAL_MORE_APPS = [
+    # ...
+    'qes',
+]
+
+# Elasticsearch connection
+ELASTICSEARCH_DSL = {
+    'default': {
+        'hosts': 'http://elasticsearch:9200',
+        # 'http_auth': ('username', 'password'),  # if security is enabled
+    }
+}
+
+# Activate/deactivate indexing of QGIS projects
+QES_INDEXING_PROJECT = True
+```
+
+### Available settings
+
+``ELASTICSEARCH_DSL``
+^^^^^^^^^^^^^^^^^^^^^
+
+Standard [`django-elasticsearch-dsl`](https://django-elasticsearch-dsl.readthedocs.io/) connection dictionary. The `default` alias is the one used by the QES indexer. Use `http_auth` to provide credentials when X-Pack security is enabled.
+
+``QES_INDEXING_PROJECT``
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Default: `True`. Master switch that enables (or disables) the automatic indexing of QGIS projects in Elasticsearch. When set to `False` the `qes` module is loaded but does not index anything and the search API returns no results.
+
+``QES_INDEXING_FIELDS``
+^^^^^^^^^^^^^^^^^^^^^^^
+
+Default: `{}` (index every attribute). Optional dictionary, keyed by QGIS layer id, that restricts the fields that will be indexed. Example:
+
+```python
+QES_INDEXING_FIELDS = {
+    'cities10000eu20171228095720113': ['name', 'country', 'population'],
+}
+```
+
+Layers that are not listed in `QES_INDEXING_FIELDS` are still fully indexed; layers that are listed are limited to the declared field names.
+
+``QES_SEARCH_QUERY``
+^^^^^^^^^^^^^^^^^^^^
+
+Elasticsearch query template used by the search endpoint. The placeholder `'$query_text'` is replaced at runtime with the text submitted by the user. The default template combines `match_phrase`, `match` (with operator `and`), `wildcard` and a fuzzy `multi_match` over the `text_content` field to balance precision and recall. Override it only if you need to tune relevance.
+
+``QES_SEARCH_SORT``
+^^^^^^^^^^^^^^^^^^^
+
+Default sort applied to search hits. Defaults to ascending `layer_id`:
+
+```python
+QES_SEARCH_SORT = {
+    "layer_id": {"order": "asc"}
+}
+```
+
+``QES_INDEXING_CRON_SCHEDULE``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Default: `None`. When set to a [Huey `crontab`](https://huey.readthedocs.io/) expression, the periodic task `es_project_cron_indexing` is scheduled and runs a full re-indexing on the defined schedule. Example — re-index every four hours:
+
+```python
+from huey import crontab
+QES_INDEXING_CRON_SCHEDULE = crontab(hour='*/4')
+```
+
+This requires the Huey consumer to be running (see the *consumer* Docker compose recipe in [docker.md](docker.md)).
+
+``QES_INDEXING_CRON_PRJIDS``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Optional, used together with `QES_INDEXING_CRON_SCHEDULE`. Space-separated list of QGIS project ids to restrict the cron-driven re-indexing to a subset of projects. If omitted, every project is re-indexed.
+
+```python
+QES_INDEXING_CRON_PRJIDS = '1 2 3'
+```
+
+## Indexing projects
+
+### One-shot indexing from the command line
+
+The `qes_indexer` management command performs a full indexing of one or more QGIS projects for every user that has permission to access them:
+
+```bash
+# Index every project
+python manage.py qes_indexer
+
+# Index only the given project ids
+python manage.py qes_indexer --prj_ids 1 2 3
+```
+
+A separate per-user index named `qgis_features_<user_pk>` is created for each user with `view_project` permission on the indexed projects.
+
+### Automatic incremental indexing
+
+When `QES_INDEXING_PROJECT = True`, G3W-SUITE listens to project save / delete and to editing commits on vector layers and updates the corresponding documents automatically. No manual action is required after the initial indexing.
+
+### Scheduled re-indexing
+
+Set `QES_INDEXING_CRON_SCHEDULE` (see above) to run a full re-indexing on a regular basis through the Huey consumer.
+
+## Search API
+
+The module exposes a per-project search endpoint backed by `QesSearchAPIView`. Issue a `GET` request to the project search URL with a `q` query parameter, for example:
+
+```
+GET /api/qes/search/<project_type>/<project_id>/?q=<text>
+```
+
+The endpoint honours the standard G3W-SUITE project permissions: anonymous users only see results from projects shared with the anonymous user, authenticated users see the subset of features that match their grants.
+
+The response is a JSON list of hits. Each hit contains:
+
+- `score` — Elasticsearch relevance score
+- `project_id`, `project_name`
+- `layer_id`, `layer_name`
+- `feature_id`
+- `attributes` — the indexed attribute values
+- `highlights` — Elasticsearch highlighting on `text_content` and `attributes.*`
+
+## Troubleshooting
+
+- **No results / empty indexes** — verify that `QES_INDEXING_PROJECT` is `True`, that the Elasticsearch service is reachable at the configured host, and that the `qes_indexer` command completes without errors. The module logs to the `elasticsearch` Python logger (`[QES-elasticsearch]` log tag).
+- **Authentication errors** — if your Elasticsearch instance has security enabled, set `http_auth` in `ELASTICSEARCH_DSL['default']`.
+- **Stale data after editing** — the receivers only update documents for the project / layer being modified. To rebuild from scratch run `python manage.py qes_indexer --prj_ids <id>`.

--- a/index.rst
+++ b/index.rst
@@ -60,6 +60,7 @@ Through the web interface of the G3W-SUITE framework it is possible to:
    social_authentication
    translation
    base_layers
+   elasticsearch
 
 
 .. toctree::


### PR DESCRIPTION
This pull request introduces documentation for the new Elasticsearch integration (QES module) in G3W-SUITE, providing a comprehensive guide for setup, configuration, and usage. It also updates the documentation agent configuration and ensures the new Elasticsearch documentation is included in the table of contents.

**Elasticsearch integration documentation:**

* Added a new `elasticsearch.md` page detailing the QES module, including setup, Docker and manual deployment instructions, configuration options, indexing strategies, API usage, and troubleshooting tips.
* Updated the main `index.rst` to include `elasticsearch` in the documentation table of contents, making the new guide discoverable for users.

**Documentation agent updates:**

* Added a new `.github/agents/docs-editor.agent.md` file describing the scope, constraints, and workflow for editing and maintaining G3W-SUITE end-user documentation, including handling of `.md` and `.rst` files, screenshots, and Sphinx builds.
